### PR TITLE
Prevent errors from unparseable dates

### DIFF
--- a/lib/feedjira/feed_entry_utilities.rb
+++ b/lib/feedjira/feed_entry_utilities.rb
@@ -28,14 +28,14 @@ module Feedjira
     # Writer for published. By default, we keep the "oldest" publish time found.
     def published=(val)
       parsed = parse_datetime(val)
-      @published = parsed if !@published || parsed < @published
+      @published = parsed if parsed && (!@published || parsed < @published)
     end
 
     ##
     # Writer for updated. By default, we keep the most recent update time found.
     def updated=(val)
       parsed = parse_datetime(val)
-      @updated = parsed if !@updated || parsed > @updated
+      @updated = parsed if parsed && (!@updated || parsed > @updated)
     end
 
     def sanitize!

--- a/spec/feedjira/feed_spec.rb
+++ b/spec/feedjira/feed_spec.rb
@@ -144,6 +144,16 @@ describe Feedjira::Feed do
         expect(feed.entries.first.published).to eq published
         expect(feed.entries.size).to eq 3
       end
+
+      it "does not fail if multiple published dates exist and some are unparseable" do
+        expect(Feedjira.logger).to receive(:warn).once
+
+        feed = Feedjira::Feed.parse(sample_invalid_date_format_feed)
+        expect(feed.title).to eq "Invalid date format feed"
+        published = Time.parse_safely "Mon, 16 Oct 2017 15:10:00 GMT"
+        expect(feed.entries.first.published).to eq published
+        expect(feed.entries.size).to eq 2
+      end
     end
 
     context "when there's no available parser" do

--- a/spec/sample_feeds.rb
+++ b/spec/sample_feeds.rb
@@ -26,7 +26,8 @@ module SampleFeeds
     sample_feed_burner_atom_xhtml_feed: 'FeedBurnerXHTML.xml',
     sample_duplicate_content_atom_feed: 'DuplicateContentAtomFeed.xml',
     sample_youtube_atom_feed: 'youtube_atom.xml',
-    sample_atom_xhtml_with_escpaed_html_in_pre_tag_feed: 'AtomEscapedHTMLInPreTag.xml'
+    sample_atom_xhtml_with_escpaed_html_in_pre_tag_feed: 'AtomEscapedHTMLInPreTag.xml',
+    sample_invalid_date_format_feed: 'InvalidDateFormat.xml',
   }.freeze
 
   FEEDS.each do |method, filename|

--- a/spec/sample_feeds/InvalidDateFormat.xml
+++ b/spec/sample_feeds/InvalidDateFormat.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+<channel>
+  <title>Invalid date format feed</title>
+  <link>http://example.com/feed</link>
+  <language>en-US</language>
+  <item>
+    <title>Item 0 with an invalid date</title>
+    <link>http://example.com/item0</link>
+    <pubDate>Mon, 16 Oct 2017 15:10:00 +0000</pubDate>
+    <dc:date>1518478934</dc:date>
+  </item>
+  <item>
+    <title>Item 1 with all valid dates</title>
+    <link>http://example.com/item1</link>
+    <pubDate>Tue, 17 Oct 2017 12:17:00 +0000</pubDate>
+    <dc:date>Tue, 17 Oct 2017 22:17:00 +0000</dc:date>
+  </item>
+</channel>


### PR DESCRIPTION
This code was raising a NoMethodError when trying to compare a nil
unparseable date with a previous successfully parsed date.